### PR TITLE
Fix ECG recovery method

### DIFF
--- a/src/beat/__init__.py
+++ b/src/beat/__init__.py
@@ -10,6 +10,7 @@ from . import (
     stimulation,
     utils,
 )
+from .ecg import ECGRecovery
 from .monodomain_model import MonodomainModel
 from .monodomain_solver import MonodomainSplittingSolver
 from .stimulation import Stimulus
@@ -29,4 +30,5 @@ __all__ = [
     "stimulation",
     "ecg",
     "Stimulus",
+    "ECGRecovery",
 ]

--- a/src/beat/conductivities.py
+++ b/src/beat/conductivities.py
@@ -11,11 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_dimension(u):
-    # TODO : Check argument
     try:
         dim = ufl.domain.find_geometric_dimension(u)
-
-    except ufl.UFLException as ex:
+    except Exception as ex:
         try:
             dim = len(u)
         except Exception as ex2:
@@ -114,5 +112,7 @@ def define_conductivity_tensor(
     g_el: float = 0.62,
     g_et: float = 0.24,
 ):
+    if f0 is None:
+        raise ValueError("f0 must be provided")
     s_l, s_t = get_harmonic_mean_conductivity(chi, g_il, g_it, g_el, g_et)
     return conductivity_tensor(s_l, s_t, f0)

--- a/tests/test_ecg.py
+++ b/tests/test_ecg.py
@@ -1,0 +1,77 @@
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import ufl
+
+import beat
+
+
+def test_ecg():
+    N = 5
+    M = 1.0
+    C_m = 1.0
+    sigma_b = 1.0
+
+    comm = MPI.COMM_WORLD
+    mesh = dolfinx.mesh.create_unit_square(comm, N, N, dolfinx.cpp.mesh.CellType.triangle)
+
+    V = dolfinx.fem.functionspace(mesh, ("P", 1))
+    v = dolfinx.fem.Function(V)
+
+    X = ufl.SpatialCoordinate(mesh)
+    v_expr = (X[0] - 0.5) ** 2
+
+    ecg = beat.ECGRecovery(v=v, M=M, C_m=C_m, sigma_b=sigma_b)
+    p1 = (1.5, 0.5)
+    p1_ecg = ecg.eval(p1)
+    p2 = (10.0, 0.5)
+    p2_ecg = ecg.eval(p2)
+    p3 = (-0.5, 0.5)
+    p3_ecg = ecg.eval(p3)
+    ecg.solve()
+
+    value = mesh.comm.allreduce(dolfinx.fem.assemble_scalar(p1_ecg), op=MPI.SUM)
+    assert np.isclose(value, 0.0)
+
+    v.interpolate(dolfinx.fem.Expression(v_expr, V.element.interpolation_points()))
+    ecg.solve()
+    value_p1 = mesh.comm.allreduce(dolfinx.fem.assemble_scalar(p1_ecg), op=MPI.SUM)
+    value_p2 = mesh.comm.allreduce(dolfinx.fem.assemble_scalar(p2_ecg), op=MPI.SUM)
+    value_p3 = mesh.comm.allreduce(dolfinx.fem.assemble_scalar(p3_ecg), op=MPI.SUM)
+
+    # The solution should be symmetric with respect to the line x=0.5
+    assert np.isclose(value_p1, value_p3)
+    # Points further away from the source should have a smaller absolute potential
+    assert abs(value_p2) < abs(value_p1)
+
+
+def test_12_leads_ecg():
+    N = 10
+    x = np.ones(N)
+    la = 1.2
+    ra = 4.5
+    ll = 3.6
+    v1 = 1.0
+    v2 = 2.0
+    v3 = 3.0
+    v4 = 4.0
+    v5 = 5.0
+    v6 = 6.0
+
+    Vw = np.mean([la, ra, ll])
+
+    ecg = beat.ecg.Leads12(
+        LA=la * x,
+        RA=ra * x,
+        LL=ll * x,
+        V1=v1 * x,
+        V2=v2 * x,
+        V3=v3 * x,
+        V4=v4 * x,
+        V5=v5 * x,
+        V6=v6 * x,
+    )
+
+    for i, vi in enumerate([v1, v2, v3, v4, v5, v6], start=1):
+        assert np.allclose(getattr(ecg, f"V{i}_"), vi - Vw)


### PR DESCRIPTION
Change API for ECG recovery method. The new way is now as follows
```python
ecg = beat.ECGRecovery(v=v, M=M, C_m=C_m, sigma_b=sigma_b)
p1 = (1.5, 0.5)
p1_ecg = ecg.eval(p1)  # return a dolfinx.fem.form

# Update v (membrane potential)
# Update ecg
ecg.solve()

# Evaluate recovery at the point
dolfinx.fem.assemble_scalar(p1_ecg)
```

Also update the demos that use ECG recovery.
