### PR TITLE
Make it possible to turn off pyvista when running niederer benchmark

### DIFF
--- a/demos/niederer_benchmark.py
+++ b/demos/niederer_benchmark.py
@@ -17,7 +17,7 @@ import numpy.typing as npt
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-if os.environ["NO_PYVISTA"] == "1":
+if os.environ.get("NO_PYVISTA", "0") == "1":
     pyvista = None
     logger.warning("Turn off pyvista")
 else:

--- a/src/beat/base_model.py
+++ b/src/beat/base_model.py
@@ -128,8 +128,8 @@ class BaseModel:
         if solver_type == "iterative":
             petsc_options = {
                 "ksp_type": "cg",
-                # "pc_type": "hypre",
-                "pc_type": "petsc_amg",
+                "pc_type": "hypre",
+                # "pc_type": "petsc_amg",
                 "pc_hypre_type": "boomeramg",
                 # "ksp_norm_type": "unpreconditioned",
                 # "ksp_atol": 1e-15,


### PR DESCRIPTION
Make it possible to run Niederer Benchmark with out using `pyvista``.
This can now be run using
```
NO_PYVISTA=1 python3 niederer_benchmark.py
```
Also make sure to pass correct petsc options to solver, see https://github.com/finsberg/fenicsx-beat/pull/18