### PR TITLE
Do not transfer values between ODE and PDE, but rather use ODE directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,20 +153,21 @@ stim_tags = dolfinx.mesh.meshtags(
 dx = ufl.Measure("dx", domain=mesh, subdomain_data=stim_tags)
 I_s = beat.Stimulus(expr=stim_expr, dZ=dx, marker=stim_marker)
 
-# Create PDE model
-pde = beat.MonodomainModel(time=time, mesh=mesh, M=0.001, I_s=I_s, dx=dx)
-
-# Next we create the PDE solver where we make sure to
+# Next we create the ODE solver where we make sure to
 # pass the variable for the membrane potential from the PDE
+v_ode = dolfinx.fem.Function(ode_space)
 ode = beat.odesolver.DolfinODESolver(
-    v_ode=dolfinx.fem.Function(ode_space),
-    v_pde=pde.state,
+    v_ode=v_ode,
     fun=fitzhughnagumo_forward_euler,
     init_states=init_states,
     parameters=parameters,
     num_states=len(init_states),
     v_index=1,
 )
+
+# Create PDE model
+pde = beat.MonodomainModel(time=time, mesh=mesh, M=0.001, I_s=I_s, dx=dx, v_ode=v_ode)
+
 
 # Combine PDE and ODE solver
 solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)

--- a/demos/fitzhughnagumo.py
+++ b/demos/fitzhughnagumo.py
@@ -185,15 +185,6 @@ I_s = beat.Stimulus(expr=stim_expr, dZ=dx, marker=stim_marker)
 
 parameters[7] = 0.0
 
-# We can now define the PDE model.
-
-pde = beat.MonodomainModel(
-    time=time,
-    mesh=mesh,
-    M=0.01,
-    I_s=I_s,
-    dx=dx,
-)
 
 # For the ODE model, we first need to define a function that will be used to solve the ODEs. We will use the same function as before in an explicit Euler scheme
 
@@ -205,14 +196,26 @@ def fun(t, states, parameters, dt):
 # We also need to specify a function space for the ODE's. We will use a simple piecewise linear function space which will solve one ODE per node in the mesh.
 
 ode_space = dolfinx.fem.functionspace(mesh, ("P", 1))
+v_ode = dolfinx.fem.Function(ode_space)
 ode = beat.odesolver.DolfinODESolver(
-    v_ode=dolfinx.fem.Function(ode_space),
-    v_pde=pde.state,
+    v_ode=v_ode,
     fun=fun,
     init_states=states,
     parameters=parameters,
     num_states=2,
     v_index=1,
+)
+
+
+# We can now define the PDE model.
+
+pde = beat.MonodomainModel(
+    time=time,
+    mesh=mesh,
+    M=0.01,
+    I_s=I_s,
+    dx=dx,
+    v_ode=v_ode,
 )
 
 # Here, we also need to specify the index of the state variable corresponding to the membrane potential, which in our case is the second state variable, with index 1.

--- a/demos/lv_endocardial.py
+++ b/demos/lv_endocardial.py
@@ -263,22 +263,11 @@ I_s = beat.stimulation.define_stimulus(
     duration=1.0,
 )
 
-# Now we are ready to create the PDE solver.
-
-pde = beat.MonodomainModel(
-    time=time,
-    mesh=geo.mesh,
-    M=M,
-    I_s=I_s,
-    C_m=C_m.to(f"uF/{mesh_unit}**2").magnitude,
-)
-
-# and the ODE solver. Here we also need to specify which space to use for the ODE solver. We will use first order Lagrange elements, which will solve one ODE per node in the mesh.
-
+# Now we are ready to create the ODE solver. Here we also need to specify which space to use for the ODE solver. We will use first order Lagrange elements, which will solve one ODE per node in the mesh.
 V_ode = dolfinx.fem.functionspace(geo.mesh, ("P", 1))
+v_ode = dolfinx.fem.Function(V_ode)
 ode = beat.odesolver.DolfinMultiODESolver(
-    v_ode=dolfinx.fem.Function(V_ode),
-    v_pde=pde.state,
+    v_ode=v_ode,
     markers=endo_epi,
     num_states={i: len(s) for i, s in init_states.items()},
     fun=fun,
@@ -286,6 +275,18 @@ ode = beat.odesolver.DolfinMultiODESolver(
     parameters=parameters,
     v_index=v_index,
 )
+
+# and the PDE solver.
+
+pde = beat.MonodomainModel(
+    time=time,
+    mesh=geo.mesh,
+    M=M,
+    I_s=I_s,
+    C_m=C_m.to(f"uF/{mesh_unit}**2").magnitude,
+    v_ode=v_ode,
+)
+
 
 # We will the the ODE and PDE using a Godunov splitting scheme. This will solve the ODE for a time step and then the PDE for a time step. This will be repeated until the end time is reached.
 

--- a/demos/monodomain_convergence.py
+++ b/demos/monodomain_convergence.py
@@ -54,6 +54,7 @@ def main():
         sharey="row",
         sharex="row",
     )
+
     for k, odespace in enumerate(odespaces):
         errors = defaultdict(list)
         error_fname = Path(f"convergence_{odespace}.json")
@@ -73,15 +74,17 @@ def main():
 
                     I_s = ac_func(x, time)
 
-                    pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s)
-
                     V_ode = beat.utils.space_from_string(odespace, mesh, dim=1)
                     v_ode = dolfinx.fem.Function(V_ode)
 
+                    pde = beat.MonodomainModel(
+                        time=time, mesh=mesh, M=M, I_s=I_s, v_ode=v_ode,
+                    )
                     s = dolfinx.fem.Function(V_ode)
                     s.interpolate(
                         dolfinx.fem.Expression(
-                            s_exact_func(x, time), V_ode.element.interpolation_points(),
+                            s_exact_func(x, time),
+                            V_ode.element.interpolation_points(),
                         ),
                     )
 
@@ -91,7 +94,6 @@ def main():
 
                     ode = beat.odesolver.DolfinODESolver(
                         v_ode=v_ode,
-                        v_pde=pde.state,
                         fun=simple_ode_forward_euler,
                         init_states=init_states,
                         parameters=None,

--- a/demos/niederer_benchmark.py
+++ b/demos/niederer_benchmark.py
@@ -176,6 +176,7 @@ params = {
     },
 }
 
+v_ode = dolfinx.fem.Function(ode_space)
 pde = beat.MonodomainModel(
     time=time_constant,
     mesh=geo.mesh,
@@ -184,10 +185,10 @@ pde = beat.MonodomainModel(
     params=params,
     C_m=C_m.to(f"uF/{mesh_unit}**2").magnitude,
     dx=I_s.dZ,
+    v_ode=v_ode,
 )
 ode = beat.odesolver.DolfinODESolver(
-    v_ode=dolfinx.fem.Function(ode_space),
-    v_pde=pde.state,
+    v_ode=v_ode,
     fun=fun,
     init_states=init_states,
     parameters=parameters,

--- a/demos/pace_train.py
+++ b/demos/pace_train.py
@@ -158,16 +158,17 @@ parameters_ode[g_Ks_index, :] = g_Ks.x.array
 # Finally we set up the models
 
 # +
+v_ode = dolfinx.fem.Function(V_ode)
 pde = beat.MonodomainModel(
     time=time,
     mesh=mesh,
+    v_ode=v_ode,
     M=D.magnitude,
     I_s=I_s,
     C_m=Cm.magnitude,
 )
 ode = beat.odesolver.DolfinODESolver(
-    v_ode=dolfinx.fem.Function(V_ode),
-    v_pde=pde.state,
+    v_ode=v_ode,
     fun=fun,
     init_states=y,
     parameters=parameters_ode,

--- a/demos/pvc.py
+++ b/demos/pvc.py
@@ -141,16 +141,17 @@ parameters_ode[g_Ks_index, :] = g_Ks.x.array
 # Finally we set up the models
 
 # +
+v_ode = dolfinx.fem.Function(V_ode)
 pde = beat.MonodomainModel(
     time=time,
     mesh=mesh,
     M=D.magnitude,
     I_s=I_s,
     C_m=Cm.magnitude,
+    v_ode=v_ode,
 )
 ode = beat.odesolver.DolfinODESolver(
-    v_ode=dolfinx.fem.Function(V_ode),
-    v_pde=pde.state,
+    v_ode=v_ode,
     fun=fun,
     init_states=y,
     parameters=parameters_ode,

--- a/joss-paper/paper.md
+++ b/joss-paper/paper.md
@@ -213,20 +213,20 @@ stim_tags = dolfinx.mesh.meshtags(
 dx = ufl.Measure("dx", domain=mesh, subdomain_data=stim_tags)
 I_s = beat.Stimulus(expr=stim_expr, dZ=dx, marker=stim_marker)
 
-# Create PDE model
-pde = beat.MonodomainModel(time=time, mesh=mesh, M=0.001, I_s=I_s, dx=dx)
-
-# Next we create the PDE solver where we make sure to
+# Next we create the ODE solver where we make sure to
 # pass the variable for the membrane potential from the PDE
+v_ode = dolfinx.fem.Function(ode_space)
 ode = beat.odesolver.DolfinODESolver(
-    v_ode=dolfinx.fem.Function(ode_space),
-    v_pde=pde.state,
+    v_ode=v_ode,
     fun=fitzhughnagumo_forward_euler,
     init_states=init_states,
     parameters=parameters,
     num_states=len(init_states),
     v_index=1,
 )
+
+# Create PDE model
+pde = beat.MonodomainModel(time=time, mesh=mesh, M=0.001, I_s=I_s, dx=dx, v_ode=v_ode)
 
 # Combine PDE and ODE solver
 solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)

--- a/src/beat/monodomain_model.py
+++ b/src/beat/monodomain_model.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 import basix
 import dolfinx
+import numpy as np
 import ufl
 from ufl.core.expr import Expr
 
@@ -33,11 +34,12 @@ class MonodomainModel(BaseModel):
         params=None,
         C_m: float = 1.0,
         dx: ufl.Measure | None = None,
+        v_ode: dolfinx.fem.Function | None = None,
         **kwargs,
     ) -> None:
         self._M = M
         self.C_m = dolfinx.fem.Constant(mesh, C_m)
-        super().__init__(mesh=mesh, time=time, params=params, I_s=I_s, dx=dx, **kwargs)
+        super().__init__(mesh=mesh, time=time, params=params, I_s=I_s, dx=dx, v_ode=v_ode, **kwargs)
 
     def _setup_state_space(self) -> None:
         # Set-up function spaces
@@ -46,7 +48,7 @@ class MonodomainModel(BaseModel):
 
         element = basix.ufl.element(family=family, cell=self._mesh.basix_cell(), degree=k)
 
-        self.V = dolfinx.fem.functionspace(self._mesh, element)
+        self._V = dolfinx.fem.functionspace(self._mesh, element)
 
         # Set-up solution fields:
         self.v_ = dolfinx.fem.Function(self.V, name="v_")
@@ -56,8 +58,15 @@ class MonodomainModel(BaseModel):
     def state(self) -> dolfinx.fem.Function:
         return self._state
 
+    @property
+    def V(self) -> dolfinx.fem.FunctionSpace:
+        """Return the function space for the state variable."""
+        return self._V
+
     def assign_previous(self):
         self.v_.x.array[:] = self.state.x.array[:]
+        if self._update_ode:
+            self.v_ode.x.array[:] = self.state.x.array[:]
 
     @staticmethod
     def default_parameters():
@@ -87,12 +96,14 @@ class MonodomainModel(BaseModel):
         w = ufl.TestFunction(self.V)
 
         # # Set-up variational problem
-        Dt_v_dt = v - self.v_
-        v_mid = theta * v + (1.0 - theta) * self.v_
-
-        theta_parabolic = ufl.inner(self._M * ufl.grad(v_mid), ufl.grad(w))
-
-        G = (self.C_m * Dt_v_dt * w + dt * theta_parabolic) * self.dx - dt * self._G_stim(w)
-        a, L = ufl.system(G)
+        a = w * v * self.dx + dt * theta * ufl.dot(ufl.grad(w), self._M * ufl.grad(v)) * self.dx
+        if np.isclose(theta, 1.0):
+            L = w * self.v_ode * self.dx + dt * self._G_stim(w)
+        else:
+            L = (
+                w * self.v_ode * self.dx
+                + dt * self._G_stim(w)
+                - dt * (1 - theta) * ufl.dot(ufl.grad(w), self._M * ufl.grad(self.v_ode)) * self.dx
+            )
 
         return a, L

--- a/src/beat/odesolver.py
+++ b/src/beat/odesolver.py
@@ -8,8 +8,6 @@ import dolfinx
 import numpy as np
 import numpy.typing as npt
 
-from .utils import local_project
-
 EPS = 1e-12
 
 
@@ -60,7 +58,6 @@ class ODESystemSolver:
 
 class BaseDolfinODESolver(abc.ABC):
     v_ode: dolfinx.fem.Function
-    v_pde: dolfinx.fem.Function
     _metadata: dict[str, Any] | None = None
 
     def _initialize_metadata(self):
@@ -76,22 +73,6 @@ class BaseDolfinODESolver(abc.ABC):
     @abc.abstractmethod
     def from_dolfin(self) -> None:
         pass
-
-    def ode_to_pde(self) -> None:
-        """Projects v_ode (DG0, quadrature space, ...) into v_pde (CG1)"""
-        local_project(
-            self.v_ode,
-            self.v_pde.function_space,
-            self.v_pde,
-        )
-
-    def pde_to_ode(self) -> None:
-        """Projects v_pde (CG1) into v_ode (DG0, quadrature space, ...)"""
-        local_project(
-            self.v_pde,
-            self.v_ode.function_space,
-            self.v_ode,
-        )
 
     @abc.abstractmethod
     def step(self, t0: float, dt: float) -> None:
@@ -114,7 +95,6 @@ class BaseDolfinODESolver(abc.ABC):
 @dataclass
 class DolfinODESolver(BaseDolfinODESolver):
     v_ode: dolfinx.fem.Function
-    v_pde: dolfinx.fem.Function
     init_states: npt.NDArray
     parameters: npt.NDArray
     fun: Callable
@@ -199,7 +179,6 @@ class DolfinODESolver(BaseDolfinODESolver):
 @dataclass
 class DolfinMultiODESolver(BaseDolfinODESolver):
     v_ode: dolfinx.fem.Function
-    v_pde: dolfinx.fem.Function
     markers: dolfinx.fem.Function
     init_states: dict[int, npt.NDArray]
     parameters: dict[int, npt.NDArray]

--- a/tests/test_monodomain_solver.py
+++ b/tests/test_monodomain_solver.py
@@ -51,10 +51,10 @@ def test_monodomain_splitting_analytic(odespace):
 
     I_s = ac_func(x, time)
 
-    pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s)
-
     V_ode = beat.utils.space_from_string(odespace, mesh, dim=1)
     v_ode = dolfinx.fem.Function(V_ode)
+
+    pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s, v_ode=v_ode)
 
     s = dolfinx.fem.Function(V_ode)
     s.interpolate(
@@ -109,11 +109,10 @@ def test_monodomain_splitting_spatial_convergence(odespace):
 
         I_s = ac_func(x, time)
 
-        pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s)
-
         V_ode = beat.utils.space_from_string(odespace, mesh, dim=1)
         v_ode = dolfinx.fem.Function(V_ode)
 
+        pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s, v_ode=v_ode)
         s = dolfinx.fem.Function(V_ode)
         s.interpolate(
             dolfinx.fem.Expression(s_exact_func(x, time), V_ode.element.interpolation_points()),
@@ -165,7 +164,6 @@ def test_monodomain_splitting_temporal_convergence(theta, odespace):
     N = 150
     mesh = dolfinx.mesh.create_unit_square(comm, N, N, dolfinx.cpp.mesh.CellType.triangle)
     V_ode = beat.utils.space_from_string(odespace, mesh, dim=1)
-    v_ode = dolfinx.fem.Function(V_ode)
 
     errors = []
 
@@ -175,8 +173,8 @@ def test_monodomain_splitting_temporal_convergence(theta, odespace):
         x = ufl.SpatialCoordinate(mesh)
 
         I_s = ac_func(x, time)
-
-        pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s)
+        v_ode = dolfinx.fem.Function(V_ode)
+        pde = beat.MonodomainModel(time=time, mesh=mesh, M=M, I_s=I_s, v_ode=v_ode)
 
         s = dolfinx.fem.Function(V_ode)
         s.interpolate(

--- a/tests/test_monodomain_solver.py
+++ b/tests/test_monodomain_solver.py
@@ -67,7 +67,6 @@ def test_monodomain_splitting_analytic(odespace):
 
     ode = beat.odesolver.DolfinODESolver(
         v_ode=v_ode,
-        v_pde=pde.state,
         fun=simple_ode_forward_euler,
         init_states=init_states,
         parameters=None,
@@ -124,7 +123,6 @@ def test_monodomain_splitting_spatial_convergence(odespace):
 
         ode = beat.odesolver.DolfinODESolver(
             v_ode=v_ode,
-            v_pde=pde.state,
             fun=simple_ode_forward_euler,
             init_states=init_states,
             parameters=None,
@@ -187,7 +185,6 @@ def test_monodomain_splitting_temporal_convergence(theta, odespace):
 
         ode = beat.odesolver.DolfinODESolver(
             v_ode=v_ode,
-            v_pde=pde.state,
             fun=simple_ode_forward_euler,
             init_states=init_states,
             parameters=None,

--- a/tests/test_odesolver.py
+++ b/tests/test_odesolver.py
@@ -53,9 +53,6 @@ def test_DolfinODESolver():
     N = 5
     mesh = dolfinx.mesh.create_unit_square(comm, N, N, dolfinx.cpp.mesh.CellType.triangle)
 
-    V_pde = dolfinx.fem.functionspace(mesh, ("P", 1))
-    v_pde = dolfinx.fem.Function(V_pde)
-
     V_ode = dolfinx.fem.functionspace(mesh, ("P", 1))
     v_ode = dolfinx.fem.Function(V_ode)
 
@@ -67,12 +64,11 @@ def test_DolfinODESolver():
     parameters = np.array([1, 1])
     ode = DolfinODESolver(
         v_ode=v_ode,
-        v_pde=v_pde,
         init_states=init_states,
         parameters=parameters,
         fun=simple_ode_forward_euler,
         num_states=2,
-        v_index=0,  # The is the index in the state vector that corresponds to PDE variable
+        v_index=0,  # The is the index in the state vector that corresponds to voltage
     )
 
     assert ode.full_values.shape == (2, N_ode)
@@ -93,16 +89,10 @@ def test_DolfinODESolver():
     ode.to_dolfin()
     # And we check that the values are updated
     assert np.allclose(v_ode.x.array, v0 - s0 * dt)
-    # However, not for the PDE function
-    assert np.allclose(v_pde.x.array, 0.0)
-    # Which is updated by the next method
-    ode.ode_to_pde()
-    assert np.allclose(v_pde.x.array, v0 - s0 * dt)
+
     # Now let us update the pde
-    v_pde.x.array[:] = 1.0
-    # And transfer the values back
-    ode.pde_to_ode()
-    assert np.allclose(v_ode.x.array, 1.0)
+    v_ode.x.array[:] = 1.0
+
     # Finally let us transfer the values back to the ODE values
     ode.from_dolfin()
     assert np.allclose(ode.values[0, :], 1.0)
@@ -121,9 +111,6 @@ def test_DolfinMultiODESolver():
     N = 5
     mesh = dolfinx.mesh.create_unit_square(comm, N, N, dolfinx.cpp.mesh.CellType.triangle)
 
-    V_pde = dolfinx.fem.functionspace(mesh, ("P", 1))
-    v_pde = dolfinx.fem.Function(V_pde)
-
     V_ode = dolfinx.fem.functionspace(mesh, ("P", 1))
     v_ode = dolfinx.fem.Function(V_ode)
 
@@ -136,17 +123,22 @@ def test_DolfinMultiODESolver():
     first_s0 = 2.0
     second_v0 = 3.0
     second_s0 = 4.0
-    init_states = {1: np.array([first_v0, first_s0]), 2: np.array([second_v0, second_s0])}
+    init_states = {
+        1: np.array([first_v0, first_s0]),
+        2: np.array([second_v0, second_s0]),
+    }
 
     first_p0 = 1
     second_p0 = 2
-    parameters = {1: np.array([first_p0, first_p0]), 2: np.array([second_p0, second_p0])}
+    parameters = {
+        1: np.array([first_p0, first_p0]),
+        2: np.array([second_p0, second_p0]),
+    }
 
     N_ode = V_ode.dofmap.index_map.size_local + V_ode.dofmap.index_map.num_ghosts
 
     ode = DolfinMultiODESolver(
         v_ode=v_ode,
-        v_pde=v_pde,
         markers=markers,
         init_states=init_states,
         parameters=parameters,
@@ -180,19 +172,13 @@ def test_DolfinMultiODESolver():
     # And we check that the values are updated
     assert np.allclose(v_ode.x.array[markers.x.array == 1], first_v0 - first_p0 * first_s0 * dt)
     assert np.allclose(v_ode.x.array[markers.x.array == 2], second_v0 - second_p0 * second_s0 * dt)
-    # However, not for the PDE function
-    assert np.allclose(v_pde.x.array, 0.0)
-    # Which is updated by the next method
-    ode.ode_to_pde()
-    assert np.allclose(v_pde.x.array[markers.x.array == 1], first_v0 - first_p0 * first_s0 * dt)
-    assert np.allclose(v_pde.x.array[markers.x.array == 2], second_v0 - second_p0 * second_s0 * dt)
-    # Now let us update the pde
-    v_pde.x.array[:] = 1.0
-    # And transfer the values back
-    ode.pde_to_ode()
-    assert np.allclose(v_ode.x.array, 1.0)
+
+    # Now let us update the ode
+    v_ode.x.array[:] = 1.0
+
     # Finally let us transfer the values back to the ODE values
     ode.from_dolfin()
+
     assert np.allclose(ode.values(1)[0, :], 1.0)
     assert np.allclose(ode.values(2)[0, :], 1.0)
     # The s value should be the same as before


### PR DESCRIPTION
Rather than transferring variables back and forth between the ODE and PDE we now use the ODE directly in the variational form of the PDE. This makes it more efficient and leads to better accuracy because we do not get any errors when interpolating between spaces. 


From a practical point of view you now need to pass the ODE variable to the PDE model instead of the opposite which was done before. In other words, code that looks like this
```python
v_ode = dolfinx.fem.Function(ode_space)
pde = beat.MonodomainModel(time=time, mesh=mesh, M=0.001, I_s=I_s, dx=dx)
ode = beat.odesolver.DolfinODESolver(
    v_ode=v_ode,
    v_pde=pde.state,
    fun=fun,
    init_states=init_states,
    parameters=parameters,
    num_states=len(init_states),
    v_index=1,
)
```

will now need to be changed to

```python
v_ode = dolfinx.fem.Function(ode_space)
ode = beat.odesolver.DolfinODESolver(
    v_ode=v_ode,
    fun=fun,
    init_states=init_states,
    parameters=parameters,
    num_states=len(init_states),
    v_index=1,
)
pde = beat.MonodomainModel(time=time, mesh=mesh, M=0.001, I_s=I_s, dx=dx, v_ode=v_ode)
```