### PR TITLE
Add fenics-dolfinx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "scifem>=0.2.14",
     "pint",
     "rich",
+    "fenics-dolfinx",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Rather than making fenics-dolfinx an implicit dependency through scifem we add it as an explicit dependency to make the error message more informative when trying to install the package when dolfinx in not allready installed, see #26 .