### PR TITLE
Fix MPI random activation points in ukb_atlas demo

### DIFF
--- a/demos/niederer_benchmark.py
+++ b/demos/niederer_benchmark.py
@@ -161,7 +161,7 @@ I_s = beat.stimulation.define_stimulus(
     amplitude=50_000.0,
 )
 
-
+assert geo.f0 is not None
 M = beat.conductivities.define_conductivity_tensor(
     f0=geo.f0,
     **conductivities,

--- a/demos/slab.py
+++ b/demos/slab.py
@@ -205,6 +205,7 @@ v_index = {
 }
 
 time = dolfinx.fem.Constant(mesh, dolfinx.default_scalar_type(0.0))
+assert data.ffun is not None
 I_s = beat.stimulation.define_stimulus(
     mesh=data.mesh,
     chi=chi,
@@ -215,6 +216,7 @@ I_s = beat.stimulation.define_stimulus(
     mesh_unit=mesh_unit,
 )
 
+assert data.f0 is not None
 M = beat.conductivities.define_conductivity_tensor(
     chi,
     f0=data.f0,

--- a/demos/ukb_atlas.py
+++ b/demos/ukb_atlas.py
@@ -17,6 +17,7 @@ import dolfinx
 import gotranx
 import beat
 import pyvista
+from dolfinx.io import VTXMeshPolicy
 
 logging.basicConfig(level=logging.INFO)
 
@@ -233,24 +234,60 @@ np.random.seed(0)
 # We will stimulate 900 points on the endocardial layer, and we do this by first finding the facets on the endocardial layer and then selecting 900 random points on these facets.
 
 num_points = 900
+
 lv_endo_facets = geo.ffun.find(geo.markers["LV"][0])
 rv_endo_facets = geo.ffun.find(geo.markers["RV"][0])
 endo_facets = np.concatenate([lv_endo_facets, rv_endo_facets])
-np.random.shuffle(endo_facets)
-endo_facets_stim = endo_facets[:num_points]
 
-# We then select the midpoints of the facets as the points to stimulate.
+# Distribute the requested number of stimulus points over MPI ranks.
+
+local_num_endo_facets = len(endo_facets)
+all_num_endo_facets = comm.allgather(local_num_endo_facets)
+total_num_endo_facets = sum(all_num_endo_facets)
+
+if total_num_endo_facets < num_points:
+    raise RuntimeError(
+        "Not enough endocardial facets to select "
+        f"{num_points} stimulus points. "
+        f"Only found {total_num_endo_facets} facets globally.",
+    )
+
+raw_counts = [
+    num_points * n / total_num_endo_facets
+    for n in all_num_endo_facets
+]
+
+stim_counts = [int(np.floor(count)) for count in raw_counts]
+missing = num_points - sum(stim_counts)
+
+fractions = [
+    raw_counts[i] - stim_counts[i]
+    for i in range(len(stim_counts))
+]
+
+for i in np.argsort(fractions)[::-1][:missing]:
+    stim_counts[i] += 1
+
+local_num_points = stim_counts[comm.rank]
+
+np.random.seed(1234 + comm.rank)
+np.random.shuffle(endo_facets)
+endo_facets_stim = endo_facets[:local_num_points]
 
 midpoints = dolfinx.mesh.compute_midpoints(geo.mesh, 2, endo_facets_stim)
-
-# We will stimulate the cells with a current of 2.5 uA/cm^2 for 2 ms starting at 0 ms.
-# The points will be activated with some delay which is a random number between 0 and 4 ms.
 
 start = 0.0
 duration = 2.0
 value = 2.5
 activation_duration = 4.0
-delays = np.random.uniform(0, activation_duration, num_points)
+
+delays = np.random.uniform(0, activation_duration, local_num_points)
+
+print(
+    f"[rank {comm.rank}] endo_facets={len(endo_facets)}, "
+    f"stim_points={len(midpoints)}, delays={len(delays)}",
+    flush=True,
+)
 
 # We now generate the expression for the stimulation. Here we also specify a tolerance of 1.0 which means that the stimulation will be applied to points that are within 1.0 mm of the midpoints.
 
@@ -317,6 +354,7 @@ vtx = dolfinx.io.VTXWriter(
     vtxfname,
     [solver.pde.state],
     engine="BP4",
+    mesh_policy=VTXMeshPolicy.reuse,
 )
 adios4dolfinx.write_mesh(checkpointfname, geo.mesh)
 

--- a/src/beat/base_model.py
+++ b/src/beat/base_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import logging
+import time
 from enum import Enum, auto
 from typing import Any, Literal, NamedTuple, Sequence
 
@@ -92,6 +93,15 @@ class BaseModel:
         self.parameters = type(self).default_parameters()
         if params is not None:
             self.parameters.update(params)
+
+        self._step_counter = 0
+        self._timing_totals: dict[str, float] = {}
+        self._ksp_total_iterations = 0
+        self._ksp_max_iterations = 0
+        self._ksp_last_iterations = 0
+        self._ksp_last_residual_norm = 0.0
+        self._ksp_last_converged_reason = 0
+
         form_compiler_options = self.parameters["form_compiler_options"]
         jit_options = self.parameters["jit_options"]
         petsc_options = self.parameters["petsc_options"]
@@ -159,6 +169,8 @@ class BaseModel:
             "jit_options": {},
             "form_compiler_options": {},
             "petsc_options": petsc_options,
+            "log_timings": False,
+            "timing_log_frequency": 1,
         }
 
     @abc.abstractmethod
@@ -200,36 +212,126 @@ class BaseModel:
         )
 
     def step(self, interval):
-        """
-        Perform a single time step.
+        """Perform a single time step.
 
         Parameters
         ----------
         interval : tuple[float, float]
             The time interval (T0, T)
-
         """
+        step_start = time.perf_counter()
+        timings: dict[str, float] = {}
 
-        # timer = dolfin.Timer("PDE Step")
-
-        # Extract interval and thus time-step
-        (t0, t1) = interval
+        # Extract interval and time step.
+        t0, t1 = interval
         dt = t1 - t0
         theta = self.parameters["theta"]
         t = t0 + theta * dt
+
+        tic = time.perf_counter()
         self.time.value = t
+        timings["pde_set_time"] = time.perf_counter() - tic
+
+        # Update matrix only when the time step changes.
+        timings["pde_update_matrices"] = 0.0
 
         # Update matrix and linear solvers etc as needed
         timestep_unchanged = abs(dt - float(self._timestep)) < 1.0e-12
+
         if not timestep_unchanged:
+            tic = time.perf_counter()
             self._timestep.value = dt
             self._update_matrices()
+            timings["pde_update_matrices"] = time.perf_counter() - tic
 
+        tic = time.perf_counter()
         self._update_rhs()
-        # Solve linear system and update ghost values in the solution
+        timings["pde_update_rhs"] = time.perf_counter() - tic
 
+        # Solve linear system and update ghost values in the solution.
+        tic = time.perf_counter()
         self._solver.solver.solve(self._solver.b, self.state.x.petsc_vec)
+        timings["pde_linear_solve"] = time.perf_counter() - tic
+
+        tic = time.perf_counter()
         self.state.x.scatter_forward()
+        timings["pde_scatter_forward"] = time.perf_counter() - tic
+
+        timings["pde_total_step"] = time.perf_counter() - step_start
+
+        self._update_ksp_summary()
+        self._log_step_timings(t0, t1, timings)
+        self._step_counter += 1
+
+    def _update_ksp_summary(self) -> None:
+        """Update accumulated PETSc/KSP solver information."""
+        ksp = self._solver.solver
+
+        iterations = int(ksp.getIterationNumber())
+        self._ksp_last_iterations = iterations
+        self._ksp_total_iterations += iterations
+        self._ksp_max_iterations = max(self._ksp_max_iterations, iterations)
+
+        try:
+            self._ksp_last_residual_norm = float(ksp.getResidualNorm())
+        except PETSc.Error:
+            self._ksp_last_residual_norm = float("nan")
+
+        try:
+            self._ksp_last_converged_reason = int(ksp.getConvergedReason())
+        except PETSc.Error:
+            self._ksp_last_converged_reason = 0
+
+    def _log_step_timings(
+        self,
+        t0: float,
+        t1: float,
+        timings: dict[str, float],
+    ) -> None:
+        """Accumulate and optionally log PDE timing information."""
+        for name, value in timings.items():
+            self._timing_totals[name] = self._timing_totals.get(name, 0.0) + value
+
+        if not self.parameters.get("log_timings", False):
+            return
+
+        timing_log_frequency = int(self.parameters.get("timing_log_frequency", 1))
+        if timing_log_frequency <= 0:
+            return
+
+        if self._step_counter % timing_log_frequency != 0:
+            return
+
+        timing_text = ", ".join(f"{name}={value:.6f}s" for name, value in timings.items())
+
+        logger.info(
+            "PDE step timing "
+            f"step={self._step_counter}, "
+            f"t=({t0:.5f}, {t1:.5f}), "
+            f"ksp_iterations={self._ksp_last_iterations}, "
+            f"ksp_residual_norm={self._ksp_last_residual_norm:.6e}, "
+            f"ksp_converged_reason={self._ksp_last_converged_reason}, "
+            f"{timing_text}",
+        )
+
+    def timing_summary(self) -> dict[str, float]:
+        """Return accumulated PDE timing information."""
+        return dict(self._timing_totals)
+
+    def ksp_summary(self) -> dict[str, float]:
+        """Return accumulated PETSc/KSP solver information."""
+        average_iterations = (
+            self._ksp_total_iterations / self._step_counter if self._step_counter > 0 else 0.0
+        )
+
+        return {
+            "ksp_total_iterations": float(self._ksp_total_iterations),
+            "ksp_average_iterations": float(average_iterations),
+            "ksp_max_iterations": float(self._ksp_max_iterations),
+            "ksp_last_iterations": float(self._ksp_last_iterations),
+            "ksp_last_residual_norm": float(self._ksp_last_residual_norm),
+            "ksp_last_converged_reason": float(self._ksp_last_converged_reason),
+        }
 
     def _G_stim(self, w):
         return sum([i.expr * w * i.dz for i in self._I_s])

--- a/src/beat/monodomain_solver.py
+++ b/src/beat/monodomain_solver.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -27,9 +28,14 @@ class MonodomainSplittingSolver:
     pde: MonodomainModel
     ode: ODESolver
     theta: float = 1.0
+    log_timings: bool = False
+    timing_log_frequency: int = 1
 
     def __post_init__(self) -> None:
         # assert np.isclose(self.theta, 1.0), "Only first order splitting is implemented"
+        self._step_counter = 0
+        self._timing_totals: dict[str, float] = {}  # timing summary.
+
         self.ode.to_dolfin()  # numpy array (ODE solver) -> dolfin function
         self.ode.ode_to_pde()  # dolfin function in ODE space (quad?) -> CG1 dolfin function
         self.pde.assign_previous()
@@ -49,44 +55,119 @@ class MonodomainSplittingSolver:
             t1 = t0 + dt
 
     def step(self, interval):
+        step_start = time.perf_counter()
+        timings: dict[str, float] = {}
+
         # Extract some parameters for readability
         theta = self.theta
 
         # Extract time domain
         (t0, t1) = interval
         logger.debug(f"Stepping from {t0} to {t1} using theta = {theta}")
+
         dt = t1 - t0
         t = t0 + theta * dt
 
         logger.debug(f"Tentative ODE step with t0={t0:.5f} dt={theta * dt:.5f}")
 
         # Solve ODE
+        tic = time.perf_counter()
         self.ode.step(t0=t0, dt=theta * dt)
+        timings["ode_step"] = time.perf_counter() - tic
+
         # Move voltage to FEniCS
+        tic = time.perf_counter()
         self.ode.to_dolfin()  # numpy array (ODE solver) -> dolfin function
+        timings["ode_to_dolfin"] = time.perf_counter() - tic
+
+        tic = time.perf_counter()
         self.ode.ode_to_pde()  # dolfin function in ODE space (quad?) -> CG1 dolfin function
+        timings["ode_to_pde"] = time.perf_counter() - tic
+
+        tic = time.perf_counter()
         self.pde.assign_previous()
+        timings["pde_assign_previous_before"] = time.perf_counter() - tic
 
         logger.debug("PDE step")
+
         # Solve PDE
+        tic = time.perf_counter()
         self.pde.step((t0, t1))
+        timings["pde_step"] = time.perf_counter() - tic
 
+        tic = time.perf_counter()
         self.ode.pde_to_ode()  # CG1 dolfin function -> dolfin function in ODE space (quad?)
-        # Copy voltage from PDE to ODE
-        self.ode.from_dolfin()
+        timings["pde_to_ode"] = time.perf_counter() - tic
 
-        # If first order splitting, we are done.
+        # Copy voltage from PDE to ODE
+        tic = time.perf_counter()
+        self.ode.from_dolfin()
+        timings["ode_from_dolfin"] = time.perf_counter() - tic
+
+        # If first order splitting, we are done. Otherwise, we need to do a corrective ODE step.
         if np.isclose(theta, 1.0):
-            # But first update previous value in PDE
-            self.pde.assign_previous()
+            tic = time.perf_counter()
+            self.pde.assign_previous()  # But first update previous value in PDE
+            timings["pde_assign_previous_after"] = time.perf_counter() - tic
+
+            timings["total_step"] = time.perf_counter() - step_start
+            self._log_step_timings(t0, t1, timings)
+            self._step_counter += 1
             return
 
         # Otherwise, we do another ode_step:
         logger.debug(f"Corrective ODE step with t0={t:5f} and dt={(1.0 - theta) * dt:.5f}")
 
         # To the correction step
+        tic = time.perf_counter()
         self.ode.step(t, (1.0 - theta) * dt)
+        timings["corrective_ode_step"] = time.perf_counter() - tic
+
         # And copy the solution back to FEniCS
+        tic = time.perf_counter()
         self.ode.to_dolfin()  # numpy array (ODE solver) -> dolfin function
+        timings["corrective_ode_to_dolfin"] = time.perf_counter() - tic
+
+        tic = time.perf_counter()
         self.ode.ode_to_pde()  # dolfin function in ODE space (quad?) -> CG1 dolfin function
+        timings["corrective_ode_to_pde"] = time.perf_counter() - tic
+
+        tic = time.perf_counter()
         self.pde.assign_previous()
+        timings["corrective_pde_assign_previous"] = time.perf_counter() - tic
+
+        timings["total_step"] = time.perf_counter() - step_start
+        self._log_step_timings(t0, t1, timings)
+        self._step_counter += 1
+
+    def _log_step_timings(
+        self,
+        t0: float,
+        t1: float,
+        timings: dict[str, float],
+    ) -> None:
+        """Accumulate and optionally log timing information for one splitting step."""
+        for name, value in timings.items():
+            self._timing_totals[name] = self._timing_totals.get(name, 0.0) + value
+
+        if not self.log_timings:
+            return
+
+        if self.timing_log_frequency <= 0:
+            return
+
+        if self._step_counter % self.timing_log_frequency != 0:
+            return
+
+        timing_text = ", ".join(f"{name}={value:.6f}s" for name, value in timings.items())
+
+        logger.info(
+            "Monodomain step timing "
+            f"step={self._step_counter}, "
+            f"t=({t0:.5f}, {t1:.5f}), "
+            f"{timing_text}",
+        )
+
+    def timing_summary(self) -> dict[str, float]:
+        """Return accumulated timing information for all completed steps."""
+        return dict(self._timing_totals)

--- a/src/beat/odesolver.py
+++ b/src/beat/odesolver.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import abc
+import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, NamedTuple
 
@@ -11,6 +13,7 @@ import numpy.typing as npt
 from .utils import local_project
 
 EPS = 1e-12
+logger = logging.getLogger(__name__)
 
 
 class ODEResults(NamedTuple):
@@ -206,8 +209,12 @@ class DolfinMultiODESolver(BaseDolfinODESolver):
     fun: dict[int, Callable]
     num_states: dict[int, int]
     v_index: dict[int, int]
+    log_timings: bool = False
+    timing_log_frequency: int = 1
 
     def __post_init__(self):
+        self._step_counter = 0
+        self._timing_totals: dict[str, float] = {}
         if self.v_ode.x.array.size != self.markers.x.array.size:
             raise RuntimeError("Marker and voltage need to be in the same function space")
 
@@ -273,8 +280,72 @@ class DolfinMultiODESolver(BaseDolfinODESolver):
         return self._num_points[marker]
 
     def step(self, t0: float, dt: float):
-        for ode in self._odes.values():
+        timings: dict[str, float] = {}
+
+        for marker, ode in self._odes.items():
+            tic = time.perf_counter()
             ode.step(t0=t0, dt=dt)
+            timings[f"marker_{marker}_ode_step"] = time.perf_counter() - tic
+
+        timings["total_ode_step"] = sum(timings.values())
+        self._log_step_timings(t0, dt, timings)
+        self._step_counter += 1
+
+    def _log_step_timings(
+        self,
+        t0: float,
+        dt: float,
+        timings: dict[str, float],
+    ) -> None:
+        """Accumulate and optionally log timing information for one ODE step."""
+        for name, value in timings.items():
+            self._timing_totals[name] = self._timing_totals.get(name, 0.0) + value
+
+        if not self.log_timings:
+            return
+
+        if self.timing_log_frequency <= 0:
+            return
+
+        if self._step_counter % self.timing_log_frequency != 0:
+            return
+
+        timing_text = ", ".join(f"{name}={value:.6f}s" for name, value in timings.items())
+
+        logger.info(
+            "Multi ODE step timing "
+            f"step={self._step_counter}, "
+            f"t0={t0:.5f}, "
+            f"dt={dt:.5f}, "
+            f"{timing_text}",
+        )
+
+    def timing_summary(self) -> dict[str, float]:
+        """Return accumulated timing information for all completed ODE steps."""
+        return dict(self._timing_totals)
+
+    def marker_summary(self) -> dict[str, float]:
+        """Return marker-wise ODE point counts and average timings."""
+        summary: dict[str, float] = {}
+
+        for marker in self._marker_values:
+            num_points = int(self._num_points[marker])
+            num_states = int(self.num_states[marker])
+            num_dofs = num_points * num_states
+
+            total_time = self._timing_totals.get(f"marker_{marker}_ode_step", 0.0)
+            average_step_time = total_time / self._step_counter if self._step_counter > 0 else 0.0
+            average_time_per_point = average_step_time / num_points if num_points > 0 else 0.0
+            average_time_per_ode_dof = average_step_time / num_dofs if num_dofs > 0 else 0.0
+
+            summary[f"marker_{marker}_num_points"] = float(num_points)
+            summary[f"marker_{marker}_num_states"] = float(num_states)
+            summary[f"marker_{marker}_ode_dofs"] = float(num_dofs)
+            summary[f"marker_{marker}_average_step_time"] = average_step_time
+            summary[f"marker_{marker}_average_time_per_point"] = average_time_per_point
+            summary[f"marker_{marker}_average_time_per_ode_dof"] = average_time_per_ode_dof
+
+        return summary
 
     def assign_all_states(self, functions: list[dolfinx.fem.Function]) -> None:
         num_states = self._values[self._marker_values[0]].shape[0]

--- a/src/beat/odesolver.py
+++ b/src/beat/odesolver.py
@@ -48,6 +48,11 @@ class ODESystemSolver:
     fun: Callable
     states: npt.NDArray
     parameters: npt.NDArray
+    log_timings: bool = False
+
+    def __post_init__(self) -> None:
+        self._step_counter = 0
+        self._timing_totals: dict[str, float] = {}
 
     @property
     def num_points(self) -> int:
@@ -58,7 +63,35 @@ class ODESystemSolver:
         return self.states.shape[0]
 
     def step(self, t0: float, dt: float) -> None:
-        self.states[:] = self.fun(states=self.states, t=t0, parameters=self.parameters, dt=dt)
+        step_start = time.perf_counter()
+
+        tic = time.perf_counter()
+        updated_states = self.fun(
+            states=self.states,
+            t=t0,
+            parameters=self.parameters,
+            dt=dt,
+        )
+        function_call_time = time.perf_counter() - tic
+
+        tic = time.perf_counter()
+        self.states[:] = updated_states
+        state_update_time = time.perf_counter() - tic
+
+        timings = {
+            "ode_function_call": function_call_time,
+            "ode_state_update": state_update_time,
+            "ode_total_step": time.perf_counter() - step_start,
+        }
+
+        for name, value in timings.items():
+            self._timing_totals[name] = self._timing_totals.get(name, 0.0) + value
+
+        self._step_counter += 1
+
+    def timing_summary(self) -> dict[str, float]:
+        """Return accumulated timing information for this ODE system."""
+        return dict(self._timing_totals)
 
 
 class BaseDolfinODESolver(abc.ABC):
@@ -123,6 +156,8 @@ class DolfinODESolver(BaseDolfinODESolver):
     fun: Callable
     num_states: int
     v_index: int = 0
+    log_timings: bool = False
+    timing_log_frequency: int = 1
 
     def __post_init__(self):
         if np.shape(self.init_states) == self.shape:
@@ -135,6 +170,7 @@ class DolfinODESolver(BaseDolfinODESolver):
             fun=self.fun,
             states=self._values,
             parameters=self.parameters,
+            log_timings=self.log_timings,
         )
         self._initialize_metadata()
 
@@ -165,6 +201,10 @@ class DolfinODESolver(BaseDolfinODESolver):
 
     def step(self, t0: float, dt: float):
         self._ode.step(t0=t0, dt=dt)
+
+    def timing_summary(self) -> dict[str, float]:
+        """Return accumulated timing information for the inner ODE system."""
+        return self._ode.timing_summary()
 
     @property
     def full_values(self):
@@ -241,6 +281,7 @@ class DolfinMultiODESolver(BaseDolfinODESolver):
                 fun=self.fun[marker],
                 states=self._values[marker],
                 parameters=self.parameters[marker],
+                log_timings=self.log_timings,
             )
         self._initialize_metadata()
 
@@ -319,6 +360,16 @@ class DolfinMultiODESolver(BaseDolfinODESolver):
             f"dt={dt:.5f}, "
             f"{timing_text}",
         )
+
+    def internal_timing_summary(self) -> dict[str, float]:
+        """Return marker-wise accumulated timing for inner ODE system steps."""
+        summary: dict[str, float] = {}
+
+        for marker, ode in self._odes.items():
+            for name, value in ode.timing_summary().items():
+                summary[f"marker_{marker}_{name}"] = value
+
+        return summary
 
     def timing_summary(self) -> dict[str, float]:
         """Return accumulated timing information for all completed ODE steps."""

--- a/src/beat/utils.py
+++ b/src/beat/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 import basix
 import dolfinx
@@ -87,7 +88,7 @@ def space_from_string(
     space_string: str,
     mesh: dolfinx.mesh.Mesh,
     dim: int = 1,
-) -> dolfinx.fem.functionspace:
+) -> dolfinx.fem.FunctionSpace:
     """
     Constructed a finite elements space from a string
     representation of the space
@@ -182,7 +183,7 @@ def expand_layer(
         dolfinx.fem.dirichletbc(1.0, epi_dofs, V),
     ]
 
-    kwargs = {}
+    kwargs: dict[str, Any] = {}
     if _dolfinx_version >= Version("0.10"):
         kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_"
 
@@ -204,7 +205,7 @@ def expand_layer(
         },
         **kwargs,
     )
-    uh = problem.solve()
+    uh = cast(dolfinx.fem.Function, problem.solve())
 
     arr = uh.x.array.copy()
     uh.x.array[:] = output_mid_marker
@@ -301,9 +302,9 @@ def expand_layer_biv(
     endo_rv_dofs = dolfinx.fem.locate_dofs_topological(V, ft.dim, ft.find(endo_rv_marker))
     epi_dofs = dolfinx.fem.locate_dofs_topological(V, ft.dim, ft.find(epi_marker))
 
-    kwargs = {}
+    lv_kwargs: dict[str, Any] = {}
     if _dolfinx_version >= Version("0.10"):
-        kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
+        lv_kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
 
     lv_problem = dolfinx.fem.petsc.LinearProblem(
         a,
@@ -313,13 +314,13 @@ def expand_layer_biv(
             dolfinx.fem.dirichletbc(1.0, epi_dofs, V),
         ],
         petsc_options=petsc_options,
-        **kwargs,
+        **lv_kwargs,
     )
-    uh_lv = lv_problem.solve()
+    uh_lv = cast(dolfinx.fem.Function, lv_problem.solve())
 
-    kwargs = {}
+    rv_kwargs: dict[str, Any] = {}
     if _dolfinx_version >= Version("0.10"):
-        kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
+        rv_kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
 
     rv_problem = dolfinx.fem.petsc.LinearProblem(
         a,
@@ -329,9 +330,9 @@ def expand_layer_biv(
             dolfinx.fem.dirichletbc(1.0, epi_dofs, V),
         ],
         petsc_options=petsc_options,
-        **kwargs,
+        **rv_kwargs,
     )
-    uh_rv = rv_problem.solve()
+    uh_rv = cast(dolfinx.fem.Function, rv_problem.solve())
 
     # In BiV we have have one epi and two endo solutions
     # We take the minimum of the two endo solutions


### PR DESCRIPTION
## Summary

This PR fixes the random activation setup in `demos/ukb_atlas.py` for MPI runs.

Previously, `num_points = 900` was applied locally on each MPI rank. This could lead to two issues: issue #61 


I kept the PR focused on the MPI handling of the random activation points in `ukb_atlas.py`. I also added mesh reuse for the VTX output and included a small mypy typing fix so that the pre-commit checks pass.