### PR TITLE
Fix MPI stimulus handling in ukb_atlas demo

### DIFF
--- a/demos/niederer_benchmark.py
+++ b/demos/niederer_benchmark.py
@@ -161,7 +161,7 @@ I_s = beat.stimulation.define_stimulus(
     amplitude=50_000.0,
 )
 
-
+assert geo.f0 is not None
 M = beat.conductivities.define_conductivity_tensor(
     f0=geo.f0,
     **conductivities,

--- a/demos/slab.py
+++ b/demos/slab.py
@@ -204,6 +204,7 @@ v_index = {
 }
 
 time = dolfinx.fem.Constant(mesh, dolfinx.default_scalar_type(0.0))
+assert data.ffun is not None
 I_s = beat.stimulation.define_stimulus(
     mesh=data.mesh,
     chi=chi,
@@ -214,9 +215,12 @@ I_s = beat.stimulation.define_stimulus(
     mesh_unit=mesh_unit,
 )
 
+fiber_direction = data.f0
+assert fiber_direction is not None
+
 M = beat.conductivities.define_conductivity_tensor(
     chi,
-    f0=data.f0,
+    f0=fiber_direction,
     g_il=g_il,
     g_it=g_it,
     g_el=g_el,

--- a/demos/ukb_atlas.py
+++ b/demos/ukb_atlas.py
@@ -17,8 +17,10 @@ import dolfinx
 import gotranx
 import beat
 import pyvista
+from dolfinx.io import VTXMeshPolicy
 
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 # Initialize the MPI communicator and create a folder to store the results
@@ -236,10 +238,53 @@ num_points = 900
 lv_endo_facets = geo.ffun.find(geo.markers["LV"][0])
 rv_endo_facets = geo.ffun.find(geo.markers["RV"][0])
 endo_facets = np.concatenate([lv_endo_facets, rv_endo_facets])
-np.random.shuffle(endo_facets)
-endo_facets_stim = endo_facets[:num_points]
 
-# We then select the midpoints of the facets as the points to stimulate.
+# Distribute the requested number of stimulus points over MPI ranks.
+
+local_num_endo_facets = len(endo_facets)
+all_num_endo_facets = comm.allgather(local_num_endo_facets)
+total_num_endo_facets = sum(all_num_endo_facets)
+
+if total_num_endo_facets < num_points:
+    raise RuntimeError(
+        "Not enough endocardial facets to select "
+        f"{num_points} stimulus points. "
+        f"Only found {total_num_endo_facets} facets globally.",
+    )
+
+# Distribute the total number of stimulus points across MPI ranks
+# proportional to the number of local endocardial facets
+
+raw_counts = [
+    num_points * n / total_num_endo_facets
+    for n in all_num_endo_facets
+]
+
+# Round down to get integer point counts. This will likely result in some points being unassigned due to rounding down, which we will handle in the next step.
+stim_counts = [int(np.floor(count)) for count in raw_counts]
+
+# Add the remaining points to the ranks with the largest fractional parts
+# so that the global number of stimulus points is exactly num_points.
+missing = num_points - sum(stim_counts)
+
+# Compute the fractional parts of the proportional counts.
+# Ranks with the largest fractional parts are the ones that were
+# closest to receiving one extra point before rounding down.
+fractions = [
+    raw_counts[i] - stim_counts[i]
+    for i in range(len(stim_counts))
+]
+
+
+for i in np.argsort(fractions)[::-1][:missing]:
+    stim_counts[i] += 1
+
+# Number of stimulus points assigned to this rank.
+local_num_points = stim_counts[comm.rank]
+
+np.random.seed(1234 + comm.rank)
+np.random.shuffle(endo_facets)
+endo_facets_stim = endo_facets[:local_num_points]
 
 midpoints = dolfinx.mesh.compute_midpoints(geo.mesh, 2, endo_facets_stim)
 
@@ -250,7 +295,15 @@ start = 0.0
 duration = 2.0
 value = 2.5
 activation_duration = 4.0
-delays = np.random.uniform(0, activation_duration, num_points)
+delays = np.random.uniform(0, activation_duration, local_num_points)
+
+logger.info(
+    "[rank %d] endo_facets=%d, stim_points=%d, delays=%d",
+    comm.rank,
+    len(endo_facets),
+    len(midpoints),
+    len(delays),
+)
 
 # We now generate the expression for the stimulation. Here we also specify a tolerance of 1.0 which means that the stimulation will be applied to points that are within 1.0 mm of the midpoints.
 
@@ -317,6 +370,7 @@ vtx = dolfinx.io.VTXWriter(
     vtxfname,
     [solver.pde.state],
     engine="BP4",
+    mesh_policy=VTXMeshPolicy.reuse,
 )
 io4dolfinx.write_mesh(checkpointfname, geo.mesh)
 

--- a/src/beat/utils.py
+++ b/src/beat/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import basix
 import dolfinx
@@ -87,7 +88,7 @@ def space_from_string(
     space_string: str,
     mesh: dolfinx.mesh.Mesh,
     dim: int = 1,
-) -> dolfinx.fem.functionspace:
+) -> dolfinx.fem.FunctionSpace:
     """
     Constructed a finite elements space from a string
     representation of the space
@@ -182,7 +183,7 @@ def expand_layer(
         dolfinx.fem.dirichletbc(1.0, epi_dofs, V),
     ]
 
-    kwargs = {}
+    kwargs: dict[str, Any] = {}
     if _dolfinx_version >= Version("0.10"):
         kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_"
 
@@ -204,7 +205,9 @@ def expand_layer(
         },
         **kwargs,
     )
-    uh = problem.solve()
+    uh_result = problem.solve()
+    assert isinstance(uh_result, dolfinx.fem.Function)
+    uh = uh_result
 
     arr = uh.x.array.copy()
     uh.x.array[:] = output_mid_marker
@@ -301,9 +304,9 @@ def expand_layer_biv(
     endo_rv_dofs = dolfinx.fem.locate_dofs_topological(V, ft.dim, ft.find(endo_rv_marker))
     epi_dofs = dolfinx.fem.locate_dofs_topological(V, ft.dim, ft.find(epi_marker))
 
-    kwargs = {}
+    lv_kwargs: dict[str, Any] = {}
     if _dolfinx_version >= Version("0.10"):
-        kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
+        lv_kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
 
     lv_problem = dolfinx.fem.petsc.LinearProblem(
         a,
@@ -313,13 +316,15 @@ def expand_layer_biv(
             dolfinx.fem.dirichletbc(1.0, epi_dofs, V),
         ],
         petsc_options=petsc_options,
-        **kwargs,
+        **lv_kwargs,
     )
-    uh_lv = lv_problem.solve()
+    uh_lv_result = lv_problem.solve()
+    assert isinstance(uh_lv_result, dolfinx.fem.Function)
+    uh_lv = uh_lv_result
 
-    kwargs = {}
+    rv_kwargs: dict[str, Any] = {}
     if _dolfinx_version >= Version("0.10"):
-        kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
+        rv_kwargs["petsc_options_prefix"] = "beat_utils_expand_layer_biv_"
 
     rv_problem = dolfinx.fem.petsc.LinearProblem(
         a,
@@ -329,9 +334,11 @@ def expand_layer_biv(
             dolfinx.fem.dirichletbc(1.0, epi_dofs, V),
         ],
         petsc_options=petsc_options,
-        **kwargs,
+        **rv_kwargs,
     )
-    uh_rv = rv_problem.solve()
+    uh_rv_result = rv_problem.solve()
+    assert isinstance(uh_rv_result, dolfinx.fem.Function)
+    uh_rv = uh_rv_result
 
     # In BiV we have have one epi and two endo solutions
     # We take the minimum of the two endo solutions


### PR DESCRIPTION
Summary
This PR fixes the random activation setup in demos/ukb_atlas.py for MPI runs.

Previously, num_points = 900 was applied locally on each MPI rank. This could lead to two issues: issue https://github.com/finsberg/fenicsx-beat/issues/61

I kept the PR focused on the MPI handling of the random activation points in ukb_atlas.py. I also added mesh reuse for the VTX output and included a small mypy typing fix so that the pre-commit checks pass.